### PR TITLE
Deprecate convertToURI in Extractor class

### DIFF
--- a/src/extra/extractor-template.js
+++ b/src/extra/extractor-template.js
@@ -13,9 +13,9 @@ class TemplateExtractor extends Extractor {
             extractor: "the name of the extractor", // must be unique among extractors
             description: "a simple description of what it does",
             parameters: [{//a list of the parameters that can be used any user
-                    name: "name of the parameter",
-                    description: "either describe or exemplify"
-                }
+                name: "name of the parameter",
+                description: "either describe or exemplify"
+            }
                 //... other parameters
             ],
             storage: { // the variables to save for this extractor (in the local storage)
@@ -47,10 +47,6 @@ class TemplateExtractor extends Extractor {
 
 
     attachIfPossible() {
-
-    }
-
-    convertToURI(original) {
 
     }
 

--- a/src/js/extractors/bills.js
+++ b/src/js/extractors/bills.js
@@ -33,7 +33,7 @@ class Bill extends Extractor {
     }
 
     attachIfPossible() {
-		$('<th>Sigtools</th>').appendTo(this._getBillsHeader()[0])
+        $('<th>Sigtools</th>').appendTo(this._getBillsHeader()[0])
         this._getBills().forEach((element, index) => {
             let event = this._parsePendingBill(element);
             let drop = getDropdown(event, this, undefined, {
@@ -48,23 +48,17 @@ class Bill extends Extractor {
         setDropdownListeners(this, undefined);
     }
 
-    convertToURI(event) {
-        event.description = encodeURIComponent(event.description);
-        event.amount = encodeURIComponent(event.amount);
-        return event;
-    }
-
     _getBills() {
         let _billsDOM = $(this.tableSelector); // array-like object
         return Array.prototype.slice.call(_billsDOM, 1); // array object, removing header row
     }
 
     _getBillsHeader() {
-		return $(this.tableSelector);
+        return $(this.tableSelector);
     }
 
     _parsePendingBill(billEl) {
-        let getDateFromBill = function(index) {
+        let getDateFromBill = function (index) {
             let dateFromBill = Bill._getDateOrUndefined($(billEl).children(`:nth(${index})`).text());
             if (dateFromBill === undefined) dateFromBill = new Date();
             return dateFromBill;

--- a/src/js/extractors/exams.js
+++ b/src/js/extractors/exams.js
@@ -88,13 +88,6 @@ class Exams extends Extractor {
         };
     }
 
-    convertToURI(event) {
-        event.subject.name = encodeURIComponent(event.subject.name);
-        event.info = encodeURIComponent(event.info);
-        event.subject.url = encodeURIComponent(event.subject.url);
-        return event;
-    }
-
     static getEvent(day, exameTd) {
         //calculate the start and end times
         let hours = exameTd.html().match(/\d+:\d+-\d+:\d+/g)[0].replace("-", " - ");

--- a/src/js/extractors/extractor.js
+++ b/src/js/extractors/extractor.js
@@ -43,13 +43,6 @@ class Extractor {
     }
 
     /**
-     * function that receives an event and clones it, and calls encodeURIComponent on the necessary elements and then returns the new object, that can be safely used in injected URIs
-     */
-    convertToURI(original) {
-        throw "Must implement convertToURI method on children of Extractor"
-    }
-
-    /**
      * simple wrapper that waits for init and then calls attachIfPossible, should be called in constructor of implementing classes
      */
     ready() {
@@ -114,11 +107,6 @@ class Extractor {
 
     getDescriptionEncoded(event) {
         return encodeURIComponent(this.getDescription(event));
-    }
-
-    _getConvertedToUri(original) {
-        let event = jQuery.extend(true, {}, original)
-        return this.convertToURI(event)
     }
 }
 

--- a/src/js/extractors/library.js
+++ b/src/js/extractors/library.js
@@ -88,15 +88,6 @@ class LibraryExtractor extends Extractor {
 
     }
 
-    convertToURI(event) {
-        event.book = encodeURIComponent(event.book);
-        event.library = encodeURIComponent(event.library);
-        event.shelf = encodeURIComponent(event.shelf);
-        event.fine = encodeURIComponent(event.fine);
-        event.renew_link = encodeURIComponent(event.renew_link);
-        return event;
-    }
-
 }
 
 // add an instance to the EXTRACTORS variable, and also trigger attachIfPossible due to constructor

--- a/src/js/extractors/moodle.js
+++ b/src/js/extractors/moodle.js
@@ -93,12 +93,6 @@ class Moodle extends Extractor {
         })
     }
 
-
-    convertToURI(event) {
-        event.url = encodeURIComponent(event.url);
-        return event;
-    }
-
     /**
      *
      * @param {*} event

--- a/src/js/extractors/single_exam.js
+++ b/src/js/extractors/single_exam.js
@@ -57,22 +57,6 @@ class SingleExam extends Extractor {
         setDropdownListeners();
     }
 
-    convertToURI(event) {
-        event.subject.name = encodeURIComponent(event.subject.name);
-        event.info = encodeURIComponent(event.info);
-        event.subject.url = encodeURIComponent(event.subject.url);
-        event.rooms = event.rooms.map(x => {
-            x.url = encodeURIComponent(x.url);
-            return x;
-        })
-        event.teachers = event.teachers.map(x => {
-            x.url = encodeURIComponent(x.url);
-            x.name = encodeURIComponent(x.name);
-            return x;
-        })
-        return event;
-    }
-
     getEvent() {
         // get array of rows
         let rows = $("table tr td:nth-child(2)").toArray()

--- a/src/js/extractors/timetable.js
+++ b/src/js/extractors/timetable.js
@@ -109,15 +109,6 @@ class Timetable extends Extractor {
         };
     }
 
-    convertToURI(event) {
-        event.name = encodeURIComponent(event.name);
-        event.teacher.name = encodeURIComponent(event.teacher.name);
-        event.teacher.url = encodeURIComponent(event.teacher.url);
-        event.room.url = encodeURIComponent(event.room.url);
-        event.klass.url = encodeURIComponent(event.klass.url);
-        return event;
-    }
-
 }
 
 $.prototype.parseTable = function(dupCols, dupRows, textMode) {


### PR DESCRIPTION
As of #86 , the `convertToURI()` method in `Extractor` class is no longer used. This PR removes all related code. If it the feature  is needed again in the future, consider automating it as suggested in #73.